### PR TITLE
Name to OID in Compute API v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +544,12 @@ dependencies = [
  "vcpkg",
  "winapi",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "diff"
@@ -1787,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "seaplane"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.20.0",
  "cfg-if",
@@ -1834,6 +1849,18 @@ dependencies = [
  "toml",
  "trycmd",
  "unicode-segmentation",
+ "uuid",
+ "wildmatch",
+]
+
+[[package]]
+name = "seaplane-oid"
+version = "0.1.0"
+dependencies = [
+ "data-encoding",
+ "once_cell",
+ "serde",
+ "thiserror",
  "uuid",
  "wildmatch",
 ]
@@ -2397,6 +2424,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
+ "atomic",
  "getrandom",
  "serde",
 ]

--- a/justfile
+++ b/justfile
@@ -178,7 +178,7 @@ test-rust: test-sdk-rust (_test-rust-crate CLI_MANIFEST) (_test-rust-api-crate C
 test-cli: (_doc-rust-crate CLI_MANIFEST) (_test-rust-crate CLI_MANIFEST) (_test-rust-api-crate CLI_MANIFEST) test-ui
 
 # Run basic integration and unit tests for the Rust SDK
-test-sdk-rust: _test-rust-crate _test-rust-api-crate (_test-rust-api-crate SDK_RUST_MANIFEST ',compute_api_v2') _doc-rust-crate
+test-sdk-rust: _test-rust-crate _test-rust-api-crate (_test-rust-api-crate SDK_RUST_MANIFEST ',compute_api_v2,unstable') _doc-rust-crate
 
 # Run basic integration and unit tests for the library container-image-ref
 test-libs-container-image-ref: (_test-rust-crate IMAGE_REF_MANIFEST)

--- a/seaplane-sdk/rust/Cargo.toml
+++ b/seaplane-sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seaplane"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/seaplane-sdk/rust/Cargo.toml
+++ b/seaplane-sdk/rust/Cargo.toml
@@ -19,6 +19,7 @@ nom = "7.1.0"
 once_cell = "1.9.0"
 regex = "1.5.4"
 reqwest = { version = "0.11.9", features = ["blocking", "json"] }
+seaplane-oid = { version = "0.1.0", path = "../../crates/oid", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.78"
 strum = { version = "0.24.0", features = ["derive"] }

--- a/seaplane-sdk/rust/src/api/compute.rs
+++ b/seaplane-sdk/rust/src/api/compute.rs
@@ -3,7 +3,7 @@ mod error;
 #[cfg(feature = "compute_api_v1")]
 pub mod v1;
 
-#[cfg(feature = "compute_api_v2")]
+#[cfg(all(feature = "compute_api_v2", feature = "unstable"))]
 pub mod v2;
 
 /// The base URL for our Compute API endpoints

--- a/seaplane-sdk/rust/src/api/compute/error.rs
+++ b/seaplane-sdk/rust/src/api/compute/error.rs
@@ -2,7 +2,10 @@ use reqwest::blocking::Response;
 
 use crate::{api::error::ApiError, error::Result};
 
-#[cfg_attr(not(any(feature = "compute_api_v1", feature = "compute_api_v2")), allow(dead_code))]
+#[cfg_attr(
+    not(any(feature = "compute_api_v1", all(feature = "compute_api_v2", feature = "unstable"))),
+    allow(dead_code)
+)]
 pub fn map_api_error(resp: Response) -> Result<Response> {
     if let Err(source) = resp.error_for_status_ref() {
         let kind = source.status().into();

--- a/seaplane-sdk/rust/src/api/compute/v2.rs
+++ b/seaplane-sdk/rust/src/api/compute/v2.rs
@@ -12,7 +12,7 @@ use crate::{
     error::{Result, SeaplaneError},
 };
 
-const COMPUTE_API_ROUTE: &str = "v2/formations";
+const COMPUTE_API_ROUTE: &str = "v2beta/formations";
 
 /// A builder struct for creating a [`FormationsRequest`] which will then be used for making a
 /// request against the `/formations` APIs

--- a/seaplane-sdk/rust/src/api/compute/v2/models.rs
+++ b/seaplane-sdk/rust/src/api/compute/v2/models.rs
@@ -65,10 +65,14 @@ mod flight_status_tests {
     fn deser() {
         let json = r#"{
             "name": "example-flight",
+            "oid": "flt-agc6amh7z527vijkv2cutplwaa",
             "health": "healthy"
         }"#;
-        let model =
-            FlightStatus { name: "example-flight".into(), health: FlightHealthStatus::Healthy };
+        let model = FlightStatus {
+            name: "example-flight".into(),
+            oid: "flt-agc6amh7z527vijkv2cutplwaa".parse().unwrap(),
+            health: FlightHealthStatus::Healthy,
+        };
 
         assert_eq!(model, serde_json::from_str(json).unwrap());
     }

--- a/seaplane-sdk/rust/src/api/compute/v2/models.rs
+++ b/seaplane-sdk/rust/src/api/compute/v2/models.rs
@@ -44,8 +44,12 @@ mod flight_health_status_tests {
 /// The status of a Flight
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 #[non_exhaustive]
+#[serde(rename_all = "kebab-case")]
 pub struct FlightStatus {
+    /// The human friendly name of the Flight
     pub name: String,
+
+    /// The health status of the Flight
     pub health: FlightHealthStatus,
 }
 
@@ -78,8 +82,12 @@ mod flight_status_tests {
 /// The status of a given Formation and it's associated Flights
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 #[non_exhaustive]
+#[serde(rename_all = "kebab-case")]
 pub struct FormationStatus {
+    /// The human friendly name of the Formation
     pub name: String,
+
+    /// The status of each Flight that is part of this Formation
     pub flights: Vec<FlightStatus>,
 }
 
@@ -122,6 +130,7 @@ mod formation_status_tests {
 /// Response from `GET /formations/NAME` which contains metadata about the Formation itself.
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 #[non_exhaustive]
+#[serde(rename_all = "kebab-case")]
 pub struct FormationMetadata {
     /// The URL where the Formation is exposed at
     pub url: String,
@@ -191,8 +200,14 @@ impl FormationBuilder {
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub struct Formation {
+    /// The human friendly name of the Formation
     name: String,
+
+    /// The Flights that make up this Formation
     flights: Vec<Flight>,
+
+    /// The Flight who will receive all the public HTTP(s) traffic that arrives on the public
+    /// Formation URL
     gateway_flight: String,
 }
 
@@ -329,6 +344,7 @@ impl FlightBuilder {
 /// balances traffic between them.
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 #[non_exhaustive]
+#[serde(rename_all = "kebab-case")]
 pub struct Flight {
     /// Returns the human readable name of the [`Flight`], which is unique with a Formation
     pub name: String,

--- a/seaplane-sdk/rust/src/api/compute/v2/models.rs
+++ b/seaplane-sdk/rust/src/api/compute/v2/models.rs
@@ -76,8 +76,11 @@ mod flight_status_tests {
     #[test]
     fn ser() {
         let json = r#"{"name":"example-flight","health":"healthy"}"#;
-        let model =
-            FlightStatus { name: "example-flight".into(), health: FlightHealthStatus::Healthy };
+        let model = FlightStatus {
+            name: "example-flight".into(),
+            oid: "flt-agc6amh7z527vijkv2cutplwaa".parse().unwrap(),
+            health: FlightHealthStatus::Healthy,
+        };
 
         assert_eq!(json, serde_json::to_string(&model).unwrap());
     }
@@ -106,12 +109,15 @@ mod formation_status_tests {
     fn deser() {
         let json = r#"{
             "name": "example-formation",
-            "flights": [{"name":"example-flight","health":"healthy"}]
+            "oid": "frm-agc6amh7z527vijkv2cutplwaa",
+            "flights": [{"name":"example-flight","oid":"flt-agc6amh7z527vijkv2cutplwaa","health":"healthy"}]
         }"#;
         let model = FormationStatus {
             name: "example-formation".into(),
+            oid: "frm-agc6amh7z527vijkv2cutplwaa".parse().unwrap(),
             flights: vec![FlightStatus {
                 name: "example-flight".into(),
+                oid: "flt-agc6amh7z527vijkv2cutplwaa".parse().unwrap(),
                 health: FlightHealthStatus::Healthy,
             }],
         };
@@ -121,11 +127,13 @@ mod formation_status_tests {
 
     #[test]
     fn ser() {
-        let json = r#"{"name":"example-formation","flights":[{"name":"example-flight","health":"healthy"}]}"#;
+        let json = r#"{"name":"example-formation","oid":"frm-agc6amh7z527vijkv2cutplwaa","flights":[{"name":"example-flight","oid":"flt-agc6amh7z527vijkv2cutplwaa","health":"healthy"}]}"#;
         let model = FormationStatus {
             name: "example-formation".into(),
+            oid: "frm-agc6amh7z527vijkv2cutplwaa".parse().unwrap(),
             flights: vec![FlightStatus {
                 name: "example-flight".into(),
+                oid: "flt-agc6amh7z527vijkv2cutplwaa".parse().unwrap(),
                 health: FlightHealthStatus::Healthy,
             }],
         };
@@ -262,13 +270,20 @@ mod formation_tests {
     fn deser() {
         let json = r#"{
             "name": "example-formation",
-            "flights": [{"name":"example-flight","image":"foo.com/bar:latest"}],
+            "oid":"frm-agc6amh7z527vijkv2cutplwaa",
+            "flights": [{
+                "name":"example-flight",
+                "oid":"flt-agc6amh7z527vijkv2cutplwaa",
+                "image":"foo.com/bar:latest"
+            }],
             "gateway-flight": "example-flight"
         }"#;
         let model = Formation {
             name: "example-formation".into(),
+            oid: Some("frm-agc6amh7z527vijkv2cutplwaa".parse().unwrap()),
             flights: vec![Flight {
                 name: "example-flight".into(),
+                oid: Some("flt-agc6amh7z527vijkv2cutplwaa".parse().unwrap()),
                 image: "foo.com/bar:latest".parse::<ImageReference>().unwrap(),
             }],
             gateway_flight: "example-flight".into(),
@@ -279,11 +294,30 @@ mod formation_tests {
 
     #[test]
     fn ser() {
+        let json = r#"{"name":"example-formation","oid":"frm-agc6amh7z527vijkv2cutplwaa","flights":[{"name":"example-flight","oid":"flt-agc6amh7z527vijkv2cutplwaa","image":"foo.com/bar:latest"}],"gateway-flight":"example-flight"}"#;
+        let model = Formation {
+            name: "example-formation".into(),
+            oid: Some("frm-agc6amh7z527vijkv2cutplwaa".parse().unwrap()),
+            flights: vec![Flight {
+                name: "example-flight".into(),
+                oid: Some("flt-agc6amh7z527vijkv2cutplwaa".parse().unwrap()),
+                image: "foo.com/bar:latest".parse::<ImageReference>().unwrap(),
+            }],
+            gateway_flight: "example-flight".into(),
+        };
+
+        assert_eq!(json.to_string(), serde_json::to_string(&model).unwrap());
+    }
+
+    #[test]
+    fn ser_no_oid() {
         let json = r#"{"name":"example-formation","flights":[{"name":"example-flight","image":"foo.com/bar:latest"}],"gateway-flight":"example-flight"}"#;
         let model = Formation {
             name: "example-formation".into(),
+            oid: None,
             flights: vec![Flight {
                 name: "example-flight".into(),
+                oid: None,
                 image: "foo.com/bar:latest".parse::<ImageReference>().unwrap(),
             }],
             gateway_flight: "example-flight".into(),
@@ -416,15 +450,14 @@ mod flight_tests {
     #[test]
     fn deser() {
         let json = r#"{
-            "name": "example-formation",
-            "flights": [{"name":"example-flight","health":"healthy"}]
+            "name":"example-flight",
+            "oid":"flt-agc6amh7z527vijkv2cutplwaa",
+            "image":"foo.com/bar:latest"
         }"#;
-        let model = FormationStatus {
-            name: "example-formation".into(),
-            flights: vec![FlightStatus {
-                name: "example-flight".into(),
-                health: FlightHealthStatus::Healthy,
-            }],
+        let model = Flight {
+            name: "example-flight".into(),
+            oid: Some("flt-agc6amh7z527vijkv2cutplwaa".parse().unwrap()),
+            image: "foo.com/bar:latest".parse::<ImageReference>().unwrap(),
         };
 
         assert_eq!(model, serde_json::from_str(json).unwrap());
@@ -432,13 +465,23 @@ mod flight_tests {
 
     #[test]
     fn ser() {
-        let json = r#"{"name":"example-formation","flights":[{"name":"example-flight","health":"healthy"}]}"#;
-        let model = FormationStatus {
-            name: "example-formation".into(),
-            flights: vec![FlightStatus {
-                name: "example-flight".into(),
-                health: FlightHealthStatus::Healthy,
-            }],
+        let json = r#"{"name":"example-flight","oid":"flt-agc6amh7z527vijkv2cutplwaa","image":"foo.com/bar:latest"}"#;
+        let model = Flight {
+            name: "example-flight".into(),
+            oid: Some("flt-agc6amh7z527vijkv2cutplwaa".parse().unwrap()),
+            image: "foo.com/bar:latest".parse::<ImageReference>().unwrap(),
+        };
+
+        assert_eq!(json, serde_json::to_string(&model).unwrap());
+    }
+
+    #[test]
+    fn ser_no_oid() {
+        let json = r#"{"name":"example-flight","image":"foo.com/bar:latest"}"#;
+        let model = Flight {
+            name: "example-flight".into(),
+            oid: None,
+            image: "foo.com/bar:latest".parse::<ImageReference>().unwrap(),
         };
 
         assert_eq!(json, serde_json::to_string(&model).unwrap());

--- a/seaplane-sdk/rust/src/api/compute/v2/models.rs
+++ b/seaplane-sdk/rust/src/api/compute/v2/models.rs
@@ -1,3 +1,4 @@
+use seaplane_oid::Oid;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
 
@@ -49,6 +50,9 @@ pub struct FlightStatus {
     /// The human friendly name of the Flight
     pub name: String,
 
+    /// The Object ID of the Flight
+    pub oid: Oid,
+
     /// The health status of the Flight
     pub health: FlightHealthStatus,
 }
@@ -86,6 +90,9 @@ mod flight_status_tests {
 pub struct FormationStatus {
     /// The human friendly name of the Formation
     pub name: String,
+
+    /// The Object ID of the Formation
+    pub oid: Oid,
 
     /// The status of each Flight that is part of this Formation
     pub flights: Vec<FlightStatus>,
@@ -134,6 +141,9 @@ mod formation_status_tests {
 pub struct FormationMetadata {
     /// The URL where the Formation is exposed at
     pub url: String,
+
+    /// The Object ID of the Formation
+    pub oid: Oid,
 }
 
 /// A builder for creating a [`Formation`] which is the primary way to describe a
@@ -189,8 +199,9 @@ impl FormationBuilder {
         }
 
         Ok(Formation {
-            flights: self.flights,
             name: self.name,
+            oid: None,
+            flights: self.flights,
             gateway_flight: self.gateway_flight.unwrap(),
         })
     }
@@ -202,6 +213,10 @@ impl FormationBuilder {
 pub struct Formation {
     /// The human friendly name of the Formation
     name: String,
+
+    /// The Object ID of the Formation that will be assigned by the Compute API upon launch
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    oid: Option<Oid>,
 
     /// The Flights that make up this Formation
     flights: Vec<Flight>,
@@ -333,7 +348,7 @@ impl FlightBuilder {
             return Err(SeaplaneError::MissingFlightImageReference);
         }
 
-        Ok(Flight { name: self.name.unwrap(), image: self.image.unwrap() })
+        Ok(Flight { name: self.name.unwrap(), oid: None, image: self.image.unwrap() })
     }
 }
 
@@ -351,6 +366,10 @@ pub struct Flight {
 
     /// The container image reference
     pub image: ImageReference,
+
+    /// The Object ID of the Flight
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oid: Option<Oid>,
 }
 
 impl Flight {

--- a/seaplane-sdk/rust/src/error.rs
+++ b/seaplane-sdk/rust/src/error.rs
@@ -22,6 +22,8 @@ pub enum SeaplaneError {
     UrlParse(#[from] url::ParseError),
     #[error("invalid json")]
     Json(#[from] serde_json::error::Error),
+    #[error("Object ID error: {0}")]
+    Oid(#[from] seaplane_oid::error::Error),
     #[error("request did not include any active configurations while force=false")]
     MissingActiveConfiguration,
     #[error("missing a required UUID")]
@@ -74,6 +76,7 @@ impl PartialEq for SeaplaneError {
             MissingFormationName => matches!(rhs, MissingFormationName),
             UrlParse(_) => matches!(rhs, UrlParse(_)),
             Json(_) => matches!(rhs, Json(_)),
+            Oid(_) => matches!(rhs, Oid(_)),
             MissingActiveConfiguration => matches!(rhs, MissingActiveConfiguration),
             MissingUuid => matches!(rhs, MissingUuid),
             ConflictingParams => matches!(rhs, ConflictingParams),

--- a/seaplane-sdk/rust/tests/api/compute_v2.rs
+++ b/seaplane-sdk/rust/tests/api/compute_v2.rs
@@ -53,8 +53,10 @@ fn build_formation() -> Formation {
 fn list_formations() {
     let resp_json = r#"[{
         "name": "example-formation",
+        "oid": "frm-agc6amh7z527vijkv2cutplwaa",
         "flights": [{
             "name": "example-flight",
+            "oid": "flt-agc6amh7z527vijkv2cutplwaa",
             "image": "registry.cplane.cloud/seaplane-demo/nginxdemos/hello:latest"
         }],
         "gateway-flight": "example-flight"
@@ -75,13 +77,15 @@ fn list_formations() {
     assert_eq!(resp, resp_t);
 }
 
-// GET /formations/NAME
+// GET /formations/OID
 #[test]
 fn get_formation() {
     let resp_json = r#"{
         "name": "example-formation",
+        "oid": "frm-agc6amh7z527vijkv2cutplwaa",
         "flights": [{
             "name": "example-flight",
+            "oid": "flt-agc6amh7z527vijkv2cutplwaa",
             "image": "registry.cplane.cloud/seaplane-demo/nginxdemos/hello:latest"
         }],
         "gateway-flight": "example-flight"
@@ -107,13 +111,16 @@ fn get_formation() {
 fn get_formation_status() {
     let resp_json = json!({
         "name": "example-formation",
+        "oid": "frm-agc6amh7z527vijkv2cutplwaa",
         "flights": [{
             "name": "example-flight",
+            "oid": "flt-agc6amh7z527vijkv2cutplwaa",
             "health": "healthy".parse::<FlightHealthStatus>().unwrap()
         }],
     });
     let mock = MOCK_SERVER.mock(|w, t| {
-        when(w, GET, "/v2beta/formations/stubb/status").header("content-type", "application/json");
+        when(w, GET, "/v2beta/formations/frm-agc6amh7z527vijkv2cutplwaa/status")
+            .header("content-type", "application/json");
         then(t, resp_json.clone());
     });
 
@@ -130,7 +137,7 @@ fn get_formation_status() {
 #[test]
 fn create_formation() {
     let mock = MOCK_SERVER.mock(|w, then| {
-        when(w, POST, "/v2beta/formations/stubb")
+        when(w, POST, "/v2beta/formations")
             .header("content-type", "application/json")
             .json_body_obj(&build_formation());
         then.status(201)
@@ -149,7 +156,8 @@ fn create_formation() {
 #[test]
 fn delete_formation() {
     let mock = MOCK_SERVER.mock(|w, t| {
-        when(w, DELETE, "/v2beta/formations/stubb").header("content-type", "application/json");
+        when(w, DELETE, "/v2beta/formations/frm-agc6amh7z527vijkv2cutplwaa")
+            .header("content-type", "application/json");
         t.status(200);
     });
 

--- a/seaplane-sdk/rust/tests/api/compute_v2.rs
+++ b/seaplane-sdk/rust/tests/api/compute_v2.rs
@@ -62,7 +62,7 @@ fn list_formations() {
     let resp_t: Vec<Formation> = serde_json::from_str(resp_json).unwrap();
 
     let mock = MOCK_SERVER.mock(|w, t| {
-        when(w, GET, "/v2/formations");
+        when(w, GET, "/v2beta/formations");
         then(t, serde_json::to_value(resp_t.clone()).unwrap());
     });
 
@@ -89,7 +89,7 @@ fn get_formation() {
     let resp_t: Formation = serde_json::from_str(resp_json).unwrap();
 
     let mock = MOCK_SERVER.mock(|w, t| {
-        when(w, GET, "/v2/formations/stubb").header("content-type", "application/json");
+        when(w, GET, "/v2beta/formations/stubb").header("content-type", "application/json");
         then(t, serde_json::to_value(resp_t.clone()).unwrap());
     });
 
@@ -113,7 +113,7 @@ fn get_formation_status() {
         }],
     });
     let mock = MOCK_SERVER.mock(|w, t| {
-        when(w, GET, "/v2/formations/stubb/status").header("content-type", "application/json");
+        when(w, GET, "/v2beta/formations/stubb/status").header("content-type", "application/json");
         then(t, resp_json.clone());
     });
 
@@ -130,7 +130,7 @@ fn get_formation_status() {
 #[test]
 fn create_formation() {
     let mock = MOCK_SERVER.mock(|w, then| {
-        when(w, POST, "/v2/formations/stubb")
+        when(w, POST, "/v2beta/formations/stubb")
             .header("content-type", "application/json")
             .json_body_obj(&build_formation());
         then.status(201)
@@ -149,7 +149,7 @@ fn create_formation() {
 #[test]
 fn delete_formation() {
     let mock = MOCK_SERVER.mock(|w, t| {
-        when(w, DELETE, "/v2/formations/stubb").header("content-type", "application/json");
+        when(w, DELETE, "/v2beta/formations/stubb").header("content-type", "application/json");
         t.status(200);
     });
 

--- a/seaplane-sdk/rust/tests/api/mod.rs
+++ b/seaplane-sdk/rust/tests/api/mod.rs
@@ -3,7 +3,7 @@
 
 #[cfg(feature = "compute_api_v1")]
 mod compute_v1;
-#[cfg(feature = "compute_api_v2")]
+#[cfg(all(feature = "compute_api_v2", feature = "unstable"))]
 mod compute_v2;
 #[cfg(feature = "locks_api_v1")]
 mod locks_v1;


### PR DESCRIPTION
This PR updates from using the name (slug) in the API itself to using the Formation OID to make requests more explicit.
